### PR TITLE
IntAttribute & basic UndoStack to undo/redo attribute's value changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ set(CMAKE_AUTOMOC ON)
 # set(CMAKE_AUTOUIC ON)
 # set(CMAKE_AUTORCC ON)
 
-find_package(Qt5 COMPONENTS Core Quick QuickControls2 REQUIRED)
+find_package(Qt5 COMPONENTS Core Quick QuickControls2 Widgets REQUIRED)
 
 file(GLOB_RECURSE SRC_FILES src/*)
 file(GLOB_RECURSE VENDOR_FILES vendor/enTT/include/*)
@@ -69,7 +69,7 @@ set_target_properties(
 target_compile_definitions(${PROJECT_NAME}
   PRIVATE $<$<OR:$<CONFIG:Debug>,$<CONFIG:RelWithDebInfo>>:QT_QML_DEBUG>)
 target_link_libraries(${PROJECT_NAME}
-  PRIVATE Qt5::Core Qt5::Quick Qt5::QuickControls2)
+  PRIVATE Qt5::Core Qt5::Quick Qt5::QuickControls2 Qt5::Widgets)
 
 # Copy qml folder after a build
 add_custom_command(

--- a/src/Core/App.cpp
+++ b/src/Core/App.cpp
@@ -1,20 +1,20 @@
 #include "Core/App.hpp"
 #include "Core/MessageHandler.hpp"
 #include "Renderer/MyQuickFBO.hpp"
-#include "UI/Tree/MyTreeNode.hpp"
 #include "UI/Tree/MyTreeModel.hpp"
+#include "UI/Tree/MyTreeNode.hpp"
 
+#include <QIcon>
+#include <QPalette>
+#include <QQmlEngine>
+#include <QQuickStyle>
 #include <QSurfaceFormat>
 #include <QtGlobal>
 #include <QtQml>
-#include <QQuickStyle>
-#include <QPalette>
-#include <QQmlEngine>
-#include <QIcon>
 
 #include "Utility/Time.hpp"
 
-App::App(int &argc, char **argv) : QGuiApplication(argc, argv)
+App::App(int &argc, char **argv) : QGuiApplication(argc, argv), _manager(this)
 {
     Time::Initialize();
 
@@ -22,7 +22,6 @@ App::App(int &argc, char **argv) : QGuiApplication(argc, argv)
 
     qmlRegisterType<MyTreeModel>("MyTree", 1, 0, "TreeModel");
     qmlRegisterType<MyTreeNode>("MyTree", 1, 0, "TreeElement");
-
 
     qInstallMessageHandler(MessageHandler::handler);
 
@@ -49,9 +48,11 @@ App::setupEngine()
 {
     _engine.addImportPath(QStringLiteral("qml"));
     const QUrl url(QStringLiteral("qml/main.qml"));
-   
+
     QQuickStyle::setStyle("Material");
     this->setWindowIcon(QIcon("qml/images/smoke_icon.png"));
+
+    _engine.rootContext()->setContextProperty("manager", &_manager);
 
     QObject::connect(
         &_engine, &QQmlApplicationEngine::objectCreated, this,
@@ -59,8 +60,6 @@ App::setupEngine()
             if (!obj && url == objUrl) QCoreApplication::exit(-1);
         },
         Qt::QueuedConnection);
-        
+
     _engine.load(url);
 }
-
-

--- a/src/Core/App.hpp
+++ b/src/Core/App.hpp
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "Core/AppManager.hpp"
+
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
-
 
 class App : public QGuiApplication
 {
@@ -16,4 +17,5 @@ class App : public QGuiApplication
 
   private:
     QQmlApplicationEngine _engine;
+    AppManager _manager;
 };

--- a/src/Core/AppManager.hpp
+++ b/src/Core/AppManager.hpp
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "UI/Attribute/Attribute.hpp"
+#include "UI/Commands.hpp"
+
+#include <QObject>
+#include <QUndoStack>
+
+/// \brief Manage the application.
+/// Designed to be used as context property for QML.
+class AppManager : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(QUndoStack *undoStack MEMBER _undoStack CONSTANT)
+
+  public:
+    explicit AppManager(QObject *parent) : QObject(parent)
+    {
+        _undoStack = new QUndoStack(this);
+    }
+    ~AppManager() = default;
+
+    // ==============================
+    // UNDOSTACK - UndoCommand methods.
+    // ==============================
+
+    /// \brief Set the value of an attribute using an UndoCommand.
+    Q_SLOT
+    void
+    setAttributeValue(Attribute *attribute, const QVariant &value) const
+    {
+        // Ownership handled by the stack.
+        _undoStack->push(new SetAttributeCommand(attribute, value));
+    }
+
+  private:
+    QUndoStack *_undoStack;
+};

--- a/src/Renderer/SdfRendererProperties.cpp
+++ b/src/Renderer/SdfRendererProperties.cpp
@@ -1,4 +1,6 @@
 #include "SdfRendererProperties.hpp"
+#include "UI/Attribute/FloatAttribute.hpp"
+#include "UI/Attribute/IntAttribute.hpp"
 
 SdfRendererProperties::SdfRendererProperties(QObject *parent)
     : QObject(parent), _attributes(new AttributeListModel(this))
@@ -15,10 +17,27 @@ SdfRendererProperties::SdfRendererProperties(QObject *parent)
     SdfRenderer_Params initialParams;
 
     // Initialize each attribute.
-    // Only one for now, for the test.
     _attributes->append(new FloatAttribute(
         "absorptionCoefficient", "Absorption Coefficient",
         initialParams.absorptionCoefficient, 0.f, 1.f, 0.01f, _attributes));
+    _attributes->append(new FloatAttribute(
+        "absorptionCutoff", "Absorption Cut-Off",
+        initialParams.absorptionCutoff, 0.f, 1.f, 0.01f, _attributes));
+    _attributes->append(new FloatAttribute(
+        "marchMultiplier", "March Multiplier", initialParams.marchMultiplier,
+        0.f, 5.f, 0.1f, _attributes));
+    _attributes->append(new IntAttribute(
+        "maxVolumeMarchSteps", "Max Volume March Steps",
+        initialParams.maxVolumeMarchSteps, 0, 100, 1, _attributes));
+    _attributes->append(new IntAttribute(
+        "maxVolumeLightMarchSteps", "Max Volume Light March Steps",
+        initialParams.maxVolumeLightMarchSteps, 0, 10, 1, _attributes));
+    _attributes->append(new IntAttribute(
+        "maxSdfSphereSteps", "Max SdF Sphere Steps",
+        initialParams.maxSdfSphereSteps, 0, 50, 1, _attributes));
+    _attributes->append(new IntAttribute(
+        "maxOpaqueShadowMarchSteps", "Max Opaque Shadow March Steps",
+        initialParams.maxOpaqueShadowMarchSteps, 0, 100, 1, _attributes));
 }
 
 const SdfRenderer_Params
@@ -28,6 +47,18 @@ SdfRendererProperties::sdfRenderer_Params() const
 
     params.absorptionCoefficient
         = _attributes->find("absorptionCoefficient")->getValue().toFloat();
+    params.absorptionCutoff
+        = _attributes->find("absorptionCutoff")->getValue().toFloat();
+    params.marchMultiplier
+        = _attributes->find("marchMultiplier")->getValue().toFloat();
+    params.maxVolumeMarchSteps
+        = _attributes->find("maxVolumeMarchSteps")->getValue().toInt();
+    params.maxVolumeLightMarchSteps
+        = _attributes->find("maxVolumeLightMarchSteps")->getValue().toInt();
+    params.maxSdfSphereSteps
+        = _attributes->find("maxSdfSphereSteps")->getValue().toInt();
+    params.maxOpaqueShadowMarchSteps
+        = _attributes->find("maxOpaqueShadowMarchSteps")->getValue().toInt();
 
     return params;
 }

--- a/src/Renderer/SdfRendererProperties.hpp
+++ b/src/Renderer/SdfRendererProperties.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "UI/Attribute/AttributeListModel.hpp"
-#include "UI/Attribute/FloatAttribute.hpp"
 
 #include <QObject>
 

--- a/src/UI/Attribute/Attribute.hpp
+++ b/src/UI/Attribute/Attribute.hpp
@@ -24,7 +24,8 @@ class Attribute : public QObject
     /// the attribute value corresponds.
     enum Type
     {
-        Float
+        Float,
+        Int
     };
     Q_ENUM(Type);
 

--- a/src/UI/Attribute/IntAttribute.hpp
+++ b/src/UI/Attribute/IntAttribute.hpp
@@ -37,10 +37,8 @@ class IntAttribute : public Attribute
     void
     setValue(const QVariant &value) override
     {
-        int newValue = value.toInt();
-        if (newValue == value) return;
-
-        _value = QVariant(newValue);
+        if (_value.toInt() == value.toInt()) return;
+        _value = value;
         Q_EMIT valueChanged();
     }
 

--- a/src/UI/Attribute/IntAttribute.hpp
+++ b/src/UI/Attribute/IntAttribute.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "Attribute.hpp"
+
+/// \brief Attribute of type Int. Basic range is [0, 100] with a step of 1.
+/// Must be used on QML Side with a Slider.
+class IntAttribute : public Attribute
+{
+    Q_OBJECT
+    Q_PROPERTY(int from MEMBER _from NOTIFY fromChanged)
+    Q_PROPERTY(int to MEMBER _to NOTIFY toChanged)
+    Q_PROPERTY(int step MEMBER _step NOTIFY stepChanged)
+  public:
+    // ==============================
+    // Constructors & Destructor.
+    // ==============================
+
+    explicit IntAttribute(const QString &name, const QString &label,
+                          const int value, const int from = 0,
+                          const int to = 100, const int step = 1,
+                          QObject *parent = nullptr)
+        : Attribute(attributeType(), name, label, value, parent), _from(from),
+          _to(to), _step(step)
+    {}
+    ~IntAttribute() = default;
+
+    // ==============================
+    // Overriding Virtual methods.
+    // ==============================
+
+    inline const Type
+    attributeType() const override
+    {
+        return Type::Int;
+    };
+
+    void
+    setValue(const QVariant &value) override
+    {
+        int newValue = value.toInt();
+        if (newValue == value) return;
+
+        _value = QVariant(newValue);
+        Q_EMIT valueChanged();
+    }
+
+  public:
+    Q_SIGNAL void fromChanged();
+    Q_SIGNAL void toChanged();
+    Q_SIGNAL void stepChanged();
+
+  private:
+    float _from; ///< Lowest value possible.
+    float _to;   ///< Highest value possible.
+    float _step; ///< Step size between values.
+};

--- a/src/UI/Commands.hpp
+++ b/src/UI/Commands.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "UI/Attribute/Attribute.hpp"
+
+#include <QUndoCommand>
+
+/// \brief Undo Stack command used to set the value of an attribute.
+class SetAttributeCommand : public QUndoCommand
+{
+  public:
+    explicit SetAttributeCommand(Attribute *attribute, const QVariant &value)
+        : QUndoCommand("Change attribute value."), _attribute(attribute),
+          _oldValue(attribute->getValue()), _value(value)
+    {}
+    ~SetAttributeCommand() = default;
+
+    void
+    undo() override
+    {
+        _attribute->setValue(_oldValue);
+    }
+
+    void
+    redo() override
+    {
+        _attribute->setValue(_value);
+    }
+
+  private:
+    Attribute *_attribute;
+    QVariant _oldValue;
+    QVariant _value;
+};


### PR DESCRIPTION
## Done

- [x] IntAttribute.
- [x] Complete SdfRendererProperties attributes model.
- [x] Creation of UndoStack.
- [x] Command used for attribute's value.

## To do on QML Side (on another branch/PR)

- Connect the buttons to the UndoStack via the **manager** context property.
- Call the good method of the **manager** to set an attribute's value.

### Little hack for sliders (QML side)

```qml
  onMoved: {
      object.value = value // When the slider moves, the value is updated (look smooth).
  }
  onPressedChanged: {
      if(pressed)
          valueOnPressed = value // Store the value when the slider is pressed (valueOnPressed should be a declared property inside the component).
      if(!pressed) {
          // When the slider is released.
          // Store the current value.
          const currentValue = value
          // Set the attribute value to the old one.
          object.value = valueOnPressed
          // Send the command with the new value (like this, the undo action will be good).
          manager.setAttributeValue(object, currentValue)
      }
  }
```
 